### PR TITLE
change strsplit to sbtab_strsplit to avoid clash with native matlab function

### DIFF
--- a/sbtab/sbtab_table_load.m
+++ b/sbtab/sbtab_table_load.m
@@ -28,7 +28,7 @@ if length(attribute_line),
     end
   end
   attr_line = strrep(attr_line,''' ',sprintf('\t'));
-  attribute_line = strsplit(sprintf('\t'),attr_line);
+  attribute_line = sbtab_strsplit(sprintf('\t'),attr_line);
 end
 
 rows = struct;
@@ -101,7 +101,7 @@ end
 
 for it=1:length(attribute_line),
  attribute_line{it} = strrep(attribute_line{it}, '= ','=');
- mm = strsplit('=',attribute_line{it});
+ mm = sbtab_strsplit('=',attribute_line{it});
  if length(mm) ==2,
    mm{2} = strrep(mm{2},'''','');
    attributes = setfield(attributes,strrep(mm{1},'!',''),mm{2});

--- a/sbtab/utils/load_unformatted_table.m
+++ b/sbtab/utils/load_unformatted_table.m
@@ -14,7 +14,7 @@ while ~stop,
   if this_line == -1, 
     stop = 1; 
   else,
-    this_line = strsplit(sprintf('\t'),this_line,'omit');
+    this_line = sbtab_strsplit(sprintf('\t'),this_line,'omit');
     T(size(T,1)+1,1:length(this_line)) = this_line;
   end
 end

--- a/sbtab/utils/sbtab_strsplit.m
+++ b/sbtab/utils/sbtab_strsplit.m
@@ -1,11 +1,11 @@
-function parts = strsplit(splitstr, str, option)
-%STRSPLIT Split string into pieces.
+function parts = sbtab_strsplit(splitstr, str, option)
+%SBTAB_STRSPLIT Split string into pieces.
 %
-%   STRSPLIT(SPLITSTR, STR, OPTION) splits the string STR at every occurrence
+%   SBTAB_STRSPLIT(SPLITSTR, STR, OPTION) splits the string STR at every occurrence
 %   of SPLITSTR and returns the result as a cell array of strings.  By default,
 %   SPLITSTR is not included in the output.
 %
-%   STRSPLIT(SPLITSTR, STR, OPTION) can be used to control how SPLITSTR is
+%   SBTAB_STRSPLIT(SPLITSTR, STR, OPTION) can be used to control how SPLITSTR is
 %   included in the output.  If OPTION is 'include', SPLITSTR will be included
 %   as a separate string.  If OPTION is 'append', SPLITSTR will be appended to
 %   each output string, as if the input string was split at the position right


### PR DESCRIPTION
This change is important for users that do not wish to replace the native implementation of strsplit with the one in sbtab-matlab.
